### PR TITLE
feat: add function and command to view details of the current error

### DIFF
--- a/lua/spec/view_error.lua
+++ b/lua/spec/view_error.lua
@@ -1,0 +1,34 @@
+-- Test to see if we have baleia installed. If we do we can use it to highlight
+-- ansi colors from command output.
+local has_baleia, baleia = pcall(function()
+  return require("baleia").setup { name = "SpecColors" }
+end)
+
+-- Highlight the buffer using baleia if it is installed.
+local highlight_buffer = function(buf)
+  if has_baleia then
+    baleia.once(buf)
+  end
+end
+
+local function view_error()
+  local point = vim.api.nvim_win_get_cursor(0)
+  local diagnostics = vim.diagnostic.get(0, { lnum = point[1] - 1 })
+
+  if #diagnostics == 0 or #diagnostics[1]["user_data"]["full_message"] == nil then
+    vim.notify "No spec error found at cursor"
+    return
+  end
+
+  local user_data = diagnostics[1]["user_data"]
+
+  vim.cmd [[edit /tmp/spec.results]]
+  vim.api.nvim_buf_set_option(0, "filetype", "results")
+  vim.api.nvim_buf_set_var(0, "bufftype", "nofile")
+
+  vim.api.nvim_buf_set_lines(0, 0, -1, false, vim.fn.split(user_data["full_message"], "\n"))
+  highlight_buffer(0)
+  vim.cmd "write"
+end
+
+return view_error

--- a/plugin/spec.lua
+++ b/plugin/spec.lua
@@ -1,5 +1,7 @@
 local runner = require "spec.runner"
+local view_error = require "spec.view_error"
 
+vim.api.nvim_create_user_command("SpecViewError", view_error, { bang = true })
 vim.api.nvim_create_user_command("SpecFile", runner.run_file, { bang = true })
 vim.api.nvim_create_user_command("SpecAtCursor", runner.run_at_cursor, { bang = true })
 vim.api.nvim_set_keymap("n", "st", "<cmd>SpecAtCursor<CR>", { nowait = true, silent = true })


### PR DESCRIPTION
Summary:

When we run our tests we are only showing the first line in the diagnostic. This is to keep things neat as some errors can get quite long.

You now get a new command `SpecViewError` this will open a new buffer and put the error output in it. If you have "baleia" installed it will use this to highlight the buffer. Any ansi codes will be replaced with colors so we get a nice view of the output.

Test Plan:

N / A, other than docs I think this will be the last thing I do before I start setting things up to actually maintain it.